### PR TITLE
Upgrade zookeeper version, bump up hbase release version

### DIFF
--- a/bigtop-packages/src/common/hbase/patch1-zookeeper-3.7.2-adminserver-exception.diff
+++ b/bigtop-packages/src/common/hbase/patch1-zookeeper-3.7.2-adminserver-exception.diff
@@ -1,0 +1,21 @@
+diff --git a/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/HQuorumPeer.java b/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/HQuorumPeer.java
+index 0193515879..89ec51ff60 100644
+--- a/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/HQuorumPeer.java
++++ b/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/HQuorumPeer.java
+@@ -44,6 +44,7 @@ import org.apache.zookeeper.server.ServerConfig;
+ import org.apache.zookeeper.server.ZooKeeperServerMain;
+ import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
+ import org.apache.zookeeper.server.quorum.QuorumPeerMain;
++import org.apache.zookeeper.server.admin.AdminServer.AdminServerException;
+ 
+ /**
+  * HBase's version of ZooKeeper's QuorumPeer. When HBase is set to manage
+@@ -83,7 +84,7 @@ public final class HQuorumPeer {
+   }
+ 
+   private static void runZKServer(QuorumPeerConfig zkConfig)
+-          throws UnknownHostException, IOException {
++          throws UnknownHostException, IOException, AdminServerException {
+     if (zkConfig.isDistributed()) {
+       QuorumPeerMain qp = new QuorumPeerMain();
+       qp.runFromConfig(zkConfig);

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -128,7 +128,7 @@ bigtop {
       name    = 'zookeeper'
       pkg     = name
       version {
-        base  = '3.4.14'
+        base  = '3.7.2'
         pkg   = base
         release = 1
       }
@@ -155,7 +155,7 @@ bigtop {
     'hbase' {
       name    = 'hbase'
       relNotes = 'Apache HBase'
-      version { base = '2.2.6'; pkg = base; release = 1 }
+      version { base = '2.2.6'; pkg = base; release = 2 }
       tarball { destination = "${name}-${version.base}.tar.gz"
                 source      = "${name}-${version.base}-src.tar.gz" }
       url     { download_path = "/$name/${version.base}/"


### PR DESCRIPTION
HBase 2.2.6 is built with zookeeper 3.4.14 by default, this version of zookeeper is not compatible with java 21. Since HBase shades the zookeeper classes, we are rebuilding HBase with zookeeper 3.7.2 and generating new rpms:

- hbase-regionserver-2.2.6-2.el8.x86_64.rpm
- hbase-master-2.2.6-2.el8.x86_64.rpm
- hbase-2.2.6-2.el8.x86_64.rpm

corresponding build job: https://csw-package-jenkins.h4.ai/job/apache-bigtop/92
